### PR TITLE
feat: add GitHub integration with OAuth device flow authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,15 @@ clap = { version = "4.5", features = ["derive", "cargo", "env"] }
 clap_complete = "4.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
+serde_json = "1.0"
 anyhow = "1.0"
 colored = "2.1"
 dirs = "5.0"
 which = "6.0"
 chrono = { version = "0.4", features = ["serde"] }
 tabled = "0.16"
+reqwest = { version = "0.12", features = ["json", "blocking"] }
+open = "5.0"
 
 [build-dependencies]
 clap = { version = "4.5", features = ["derive", "cargo", "env"] }

--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ gwt add bugfix/login-error
 gwt list
 
 # Output:
-# ┌────────────────────────────────────┬────────────────────┬─────────────┐
-# │ PATH                               │ BRANCH             │ HEAD        │
-# ├────────────────────────────────────┼────────────────────┼─────────────┤
-# │ /path/to/main                      │ main               │ abc123d...  │
-# │ /path/to/feature/user-auth         │ feature/user-auth  │ def456e...  │
-# │ /path/to/bugfix/login-error        │ bugfix/login-error │ ghi789f...  │
-# └────────────────────────────────────┴────────────────────┴─────────────┘
+# ┌────────────────────┬─────────────────────────────────────────────────────┐
+# │ BRANCH             │ PULL REQUEST                                        │
+# ├────────────────────┼─────────────────────────────────────────────────────┤
+# │ main               │ -                                                   │
+# │ feature/user-auth  │ https://github.com/owner/repo/pull/42 (open)       │
+# │ bugfix/login-error │ https://github.com/owner/repo/pull/41 (draft)      │
+# └────────────────────┴─────────────────────────────────────────────────────┘
 ```
 
 ### 4. Switch Between Work
@@ -242,6 +242,47 @@ hooks:
 
 By default, all hooks are commented out (disabled) - uncomment the ones you want to use.
 
+## GitHub Integration
+
+View GitHub pull request information directly in your worktree list!
+
+### Setup GitHub Authentication
+```bash
+# Authenticate with GitHub (one-time setup)
+gwt auth github
+
+# This will:
+# 1. Open your browser to GitHub
+# 2. Display a code to enter
+# 3. Save your authentication securely
+```
+
+### View PR Status
+```bash
+# List worktrees with PR info
+gwt list
+
+# Shows PR URL and status for each branch
+# ┌────────────────────┬─────────────────────────────────────────────────────┐
+# │ BRANCH             │ PULL REQUEST                                        │
+# ├────────────────────┼─────────────────────────────────────────────────────┤
+# │ main               │ -                                                   │
+# │ feature/new-ui     │ https://github.com/owner/repo/pull/123 (open)      │
+# │ fix/memory-leak    │ https://github.com/owner/repo/pull/122 (draft)     │
+# └────────────────────┴─────────────────────────────────────────────────────┘
+```
+
+### Managing Authentication
+```bash
+# Check authentication status
+gwt auth github
+
+# Remove stored credentials
+gwt auth github --logout
+```
+
+For setup instructions, see [docs/GITHUB_AUTH_SETUP.md](docs/GITHUB_AUTH_SETUP.md).
+
 ## Benefits
 
 - **🚀 No Context Switching**: Each branch keeps its own working directory
@@ -252,6 +293,7 @@ By default, all hooks are commented out (disabled) - uncomment the ones you want
 - **🪝 Smart Automation**: Hooks automatically run setup/cleanup tasks
 - **📊 Real-time Feedback**: See command output as it executes
 - **🎯 Tab Completion**: Branch names auto-complete for add/remove commands
+- **🔗 GitHub Integration**: View pull request status directly in worktree list
 
 ## Requirements
 

--- a/docs/GITHUB_AUTH_SETUP.md
+++ b/docs/GITHUB_AUTH_SETUP.md
@@ -1,0 +1,73 @@
+# GitHub OAuth App Setup for git-worktree-cli
+
+This guide explains how to set up GitHub OAuth authentication for `gwt` to display pull request information.
+
+## Why OAuth Device Flow?
+
+The OAuth device flow provides:
+- **Better security**: No need to store long-lived personal access tokens
+- **Easier setup**: Users don't need to manually create and manage tokens
+- **Better UX**: Simple browser-based authentication flow
+
+## Setting Up the OAuth App
+
+### For Development/Personal Use
+
+1. Go to [GitHub Settings > Developer settings > OAuth Apps](https://github.com/settings/developers)
+2. Click "New OAuth App"
+3. Fill in the details:
+   - **Application name**: `git-worktree-cli` (or your preferred name)
+   - **Homepage URL**: `https://github.com/yourusername/git-worktree-cli`
+   - **Authorization callback URL**: `http://localhost` (required but not used)
+   - **Enable Device Flow**: ✅ **Check this box**
+4. Click "Register application"
+5. Copy the **Client ID** (you'll need this in the next step)
+
+### Configuring the Client ID
+
+Edit `src/github.rs` and replace `YOUR_CLIENT_ID_HERE` with your actual Client ID:
+
+```rust
+const CLIENT_ID: &str = "your_actual_client_id_here";
+```
+
+### For Production/Distribution
+
+For a production release, you have several options:
+
+1. **Environment Variable**: Instead of hardcoding, read from environment:
+   ```rust
+   const CLIENT_ID: &str = env!("GWT_GITHUB_CLIENT_ID");
+   ```
+
+2. **Build-time Configuration**: Use a build script to inject the ID
+
+3. **Runtime Configuration**: Store in a config file
+
+## Using GitHub Authentication
+
+Once configured and built:
+
+```bash
+# Authenticate with GitHub
+gwt auth github
+
+# List worktrees with PR information
+gwt list
+
+# Logout (remove stored token)
+gwt auth github --logout
+```
+
+## Security Notes
+
+- The OAuth device flow doesn't require a client secret
+- Access tokens are stored securely in `~/.config/gwt/auth.json` with 600 permissions
+- Tokens can be revoked at any time from GitHub settings
+- The app only requests `repo` scope for PR access
+
+## Troubleshooting
+
+- If authentication fails, check that "Enable Device Flow" is checked in your OAuth app settings
+- Ensure your Client ID is correctly set in the source code
+- Check that you have internet connectivity during authentication

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,16 @@ pub enum CompletionAction {
 }
 
 #[derive(Subcommand)]
+pub enum AuthAction {
+    /// Authenticate with GitHub
+    Github {
+        /// Logout and remove stored credentials
+        #[arg(long)]
+        logout: bool,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum Commands {
     /// Initialize a new worktree project from a repository URL
     Init {
@@ -55,6 +65,12 @@ pub enum Commands {
     Remove {
         /// Branch name to remove (current worktree if not specified)
         branch_name: Option<String>,
+    },
+
+    /// Manage authentication for external services
+    Auth {
+        #[command(subcommand)]
+        action: AuthAction,
     },
 
     /// Generate or install shell completions

--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+use crate::github::GitHubClient;
+
+pub fn run(logout: bool) -> Result<()> {
+    if logout {
+        GitHubClient::logout()?;
+    } else {
+        let client = GitHubClient::new();
+        if client.has_auth() {
+            println!("✓ You are already authenticated with GitHub");
+            println!("Run 'gwt auth github --logout' to remove stored credentials");
+        } else {
+            client.authenticate()?;
+        }
+    }
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod init;
 pub mod add;
+pub mod auth;
 pub mod list;
 pub mod remove;

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,367 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::thread;
+use std::time;
+
+// GitHub OAuth App Client ID
+// This should be moved to a config file or environment variable in production
+const CLIENT_ID: &str = "YOUR_CLIENT_ID_HERE";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PullRequest {
+    pub number: u32,
+    pub title: String,
+    pub state: String,
+    pub html_url: String,
+    pub draft: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct AuthToken {
+    access_token: String,
+    token_type: String,
+    scope: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceCodeResponse {
+    device_code: String,
+    user_code: String,
+    verification_uri: String,
+    expires_in: u32,
+    interval: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccessTokenResponse {
+    access_token: String,
+    token_type: String,
+    scope: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrorResponse {
+    error: String,
+    error_description: Option<String>,
+}
+
+pub struct GitHubClient {
+    token: Option<String>,
+    client: reqwest::blocking::Client,
+}
+
+impl GitHubClient {
+    pub fn new() -> Self {
+        let client = reqwest::blocking::Client::builder()
+            .user_agent("git-worktree-cli")
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self {
+            token: Self::load_token(),
+            client,
+        }
+    }
+
+    fn load_token() -> Option<String> {
+        // Priority order:
+        // 1. Environment variable GITHUB_TOKEN
+        // 2. Stored OAuth token from device flow
+        // 3. gh CLI auth token (fallback)
+
+        // Check environment variable
+        if let Ok(token) = env::var("GITHUB_TOKEN") {
+            if !token.is_empty() {
+                return Some(token);
+            }
+        }
+
+        // Check stored OAuth token
+        if let Ok(auth_token) = Self::load_auth_token() {
+            // Check if token is expired
+            if let Some(expires_at) = auth_token.expires_at {
+                if expires_at > Utc::now() {
+                    return Some(auth_token.access_token);
+                }
+            } else {
+                // No expiration, assume it's valid
+                return Some(auth_token.access_token);
+            }
+        }
+
+        // Check gh CLI as fallback
+        Self::get_gh_token()
+    }
+
+    fn get_gh_token() -> Option<String> {
+        std::process::Command::new("gh")
+            .args(["auth", "token"])
+            .output()
+            .ok()
+            .and_then(|output| {
+                if output.status.success() {
+                    String::from_utf8(output.stdout)
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                } else {
+                    None
+                }
+            })
+    }
+
+    fn auth_file_path() -> Result<PathBuf> {
+        let config_dir = dirs::config_dir()
+            .ok_or_else(|| anyhow!("Could not determine config directory"))?;
+        Ok(config_dir.join("gwt").join("auth.json"))
+    }
+
+    fn load_auth_token() -> Result<AuthToken> {
+        let path = Self::auth_file_path()?;
+        if !path.exists() {
+            return Err(anyhow!("Auth file does not exist"));
+        }
+
+        let content = fs::read_to_string(&path)?;
+        let token: AuthToken = serde_json::from_str(&content)?;
+        Ok(token)
+    }
+
+    fn save_auth_token(token: &AuthToken) -> Result<()> {
+        let path = Self::auth_file_path()?;
+        
+        // Create directory if it doesn't exist
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let json = serde_json::to_string_pretty(&token)?;
+        fs::write(&path, json)?;
+
+        // Set restrictive permissions (owner read/write only)
+        #[cfg(unix)]
+        {
+            let metadata = fs::metadata(&path)?;
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o600);
+            fs::set_permissions(&path, perms)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn has_auth(&self) -> bool {
+        self.token.is_some()
+    }
+
+    pub fn authenticate(&self) -> Result<()> {
+        println!("{}", "Starting GitHub authentication...".green());
+
+        // Request device code
+        let device_response = self.request_device_code()?;
+
+        println!("\n{}", "Please visit this URL in your browser:".yellow());
+        println!("{}", device_response.verification_uri.blue().underline());
+        println!("\n{}", "Enter this code:".yellow());
+        println!("{}", device_response.user_code.green().bold());
+
+        // Try to open the URL in the default browser
+        if open::that(&device_response.verification_uri).is_ok() {
+            println!("\n{}", "Opening browser...".dimmed());
+        }
+
+        println!("\n{}", "Waiting for authorization...".dimmed());
+
+        // Poll for access token
+        let access_token = self.poll_for_token(&device_response)?;
+
+        // Save the token
+        let auth_token = AuthToken {
+            access_token: access_token.access_token,
+            token_type: access_token.token_type,
+            scope: access_token.scope,
+            expires_at: None, // GitHub tokens don't expire by default
+        };
+
+        Self::save_auth_token(&auth_token)?;
+
+        println!("\n{}", "✓ Authentication successful!".green().bold());
+        println!("{}", "Your authentication token has been saved.".dimmed());
+
+        Ok(())
+    }
+
+    fn request_device_code(&self) -> Result<DeviceCodeResponse> {
+        let params = [
+            ("client_id", CLIENT_ID),
+            ("scope", "repo"),
+        ];
+
+        let response = self.client
+            .post("https://github.com/login/device/code")
+            .header("Accept", "application/json")
+            .form(&params)
+            .send()
+            .context("Failed to request device code")?;
+
+        if response.status().is_success() {
+            response.json::<DeviceCodeResponse>()
+                .context("Failed to parse device code response")
+        } else {
+            let error: ErrorResponse = response.json()
+                .context("Failed to parse error response")?;
+            Err(anyhow!("GitHub API error: {} - {}", 
+                error.error, 
+                error.error_description.unwrap_or_default()))
+        }
+    }
+
+    fn poll_for_token(&self, device_response: &DeviceCodeResponse) -> Result<AccessTokenResponse> {
+        let expiry = Utc::now() + Duration::seconds(device_response.expires_in as i64);
+        let poll_interval = time::Duration::from_secs(device_response.interval as u64);
+
+        loop {
+            if Utc::now() > expiry {
+                return Err(anyhow!("Device code expired. Please try again."));
+            }
+
+            thread::sleep(poll_interval);
+
+            let params = [
+                ("client_id", CLIENT_ID),
+                ("device_code", &device_response.device_code),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ];
+
+            let response = self.client
+                .post("https://github.com/login/oauth/access_token")
+                .header("Accept", "application/json")
+                .form(&params)
+                .send()
+                .context("Failed to poll for access token")?;
+
+            if response.status().is_success() {
+                let body = response.text()?;
+                
+                // Check if it's an error response
+                if body.contains("\"error\"") {
+                    let error: ErrorResponse = serde_json::from_str(&body)?;
+                    match error.error.as_str() {
+                        "authorization_pending" => {
+                            // User hasn't authorized yet, continue polling
+                            print!(".");
+                            use std::io::{self, Write};
+                            io::stdout().flush().ok();
+                            continue;
+                        }
+                        "slow_down" => {
+                            // We're polling too fast, wait longer
+                            thread::sleep(poll_interval);
+                            continue;
+                        }
+                        _ => {
+                            return Err(anyhow!("Authorization failed: {} - {}", 
+                                error.error,
+                                error.error_description.unwrap_or_default()));
+                        }
+                    }
+                } else {
+                    // Success! Parse the access token
+                    let token: AccessTokenResponse = serde_json::from_str(&body)?;
+                    return Ok(token);
+                }
+            } else {
+                return Err(anyhow!("Failed to poll for access token: {}", response.status()));
+            }
+        }
+    }
+
+    pub fn get_pull_requests(&self, owner: &str, repo: &str, branch: &str) -> Result<Vec<PullRequest>> {
+        let token = self.token.as_ref()
+            .ok_or_else(|| anyhow!("No GitHub authentication found. Run 'gwt auth github' to authenticate."))?;
+
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/pulls?head={}:{}&state=all",
+            owner, repo, owner, branch
+        );
+
+        let response = self.client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Accept", "application/vnd.github.v3+json")
+            .send()
+            .context("Failed to fetch pull requests")?;
+
+        if response.status().is_success() {
+            let prs: Vec<serde_json::Value> = response.json()
+                .context("Failed to parse pull requests")?;
+
+            Ok(prs.into_iter().map(|pr| PullRequest {
+                number: pr["number"].as_u64().unwrap_or(0) as u32,
+                title: pr["title"].as_str().unwrap_or("").to_string(),
+                state: pr["state"].as_str().unwrap_or("").to_string(),
+                html_url: pr["html_url"].as_str().unwrap_or("").to_string(),
+                draft: pr["draft"].as_bool().unwrap_or(false),
+            }).collect())
+        } else if response.status() == 401 {
+            Err(anyhow!("GitHub authentication failed. Run 'gwt auth github' to re-authenticate."))
+        } else {
+            Err(anyhow!("Failed to fetch pull requests: {}", response.status()))
+        }
+    }
+
+    pub fn parse_github_url(url: &str) -> Option<(String, String)> {
+        // Parse both HTTPS and SSH URLs
+        if let Some(captures) = url.strip_prefix("https://github.com/") {
+            let parts: Vec<&str> = captures.trim_end_matches(".git").split('/').collect();
+            if parts.len() >= 2 {
+                return Some((parts[0].to_string(), parts[1].to_string()));
+            }
+        } else if let Some(captures) = url.strip_prefix("git@github.com:") {
+            let parts: Vec<&str> = captures.trim_end_matches(".git").split('/').collect();
+            if parts.len() >= 2 {
+                return Some((parts[0].to_string(), parts[1].to_string()));
+            }
+        }
+        None
+    }
+
+    pub fn logout() -> Result<()> {
+        let path = Self::auth_file_path()?;
+        if path.exists() {
+            fs::remove_file(&path)?;
+            println!("{}", "✓ Successfully logged out from GitHub".green());
+        } else {
+            println!("{}", "No stored authentication found".yellow());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_github_url() {
+        let test_cases = vec![
+            ("https://github.com/owner/repo.git", Some(("owner".to_string(), "repo".to_string()))),
+            ("https://github.com/owner/repo", Some(("owner".to_string(), "repo".to_string()))),
+            ("git@github.com:owner/repo.git", Some(("owner".to_string(), "repo".to_string()))),
+            ("git@github.com:owner/repo", Some(("owner".to_string(), "repo".to_string()))),
+            ("https://gitlab.com/owner/repo", None),
+        ];
+
+        for (url, expected) in test_cases {
+            assert_eq!(GitHubClient::parse_github_url(url), expected);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,11 +7,12 @@ mod commands;
 mod completions;
 mod config;
 mod git;
+mod github;
 mod hooks;
 mod utils;
 
-use cli::{Cli, Commands, CompletionAction};
-use commands::{add, init, list, remove};
+use cli::{Cli, Commands, CompletionAction, AuthAction};
+use commands::{add, auth, init, list, remove};
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -28,6 +29,13 @@ fn main() -> Result<()> {
         }
         Commands::Remove { branch_name } => {
             remove::run(branch_name.as_deref())?;
+        }
+        Commands::Auth { action } => {
+            match action {
+                AuthAction::Github { logout } => {
+                    auth::run(logout)?;
+                }
+            }
         }
         Commands::Completions { action } => {
             handle_completions(action)?;


### PR DESCRIPTION
- Add new `gwt auth github` command for GitHub authentication using OAuth device flow
- Update `gwt list` to show pull request URLs and status (colored)
- Implement secure token storage in ~/.config/gwt/auth.json
- Add reqwest and open dependencies for HTTP requests and browser opening
- Support environment variable GITHUB_TOKEN as authentication fallback
- Add documentation for setting up GitHub OAuth app
- Update README with GitHub integration features

The implementation uses GitHub's OAuth device flow for a secure and user-friendly authentication experience. Pull request information is fetched via GitHub API and displayed in the worktree list with clickable URLs and color-coded status.

Command usage:
- `gwt auth github` - authenticate with GitHub
- `gwt auth github --logout` - remove stored credentials
- `gwt list` - show worktrees with PR URLs