### PR TITLE
fix: remove all compiler warnings

### DIFF
--- a/src/bitbucket_data_center_api.rs
+++ b/src/bitbucket_data_center_api.rs
@@ -111,10 +111,14 @@ pub struct BitbucketDataCenterPullRequest {
 #[derive(Debug, Deserialize)]
 pub struct BitbucketDataCenterPullRequestsResponse {
     pub values: Vec<BitbucketDataCenterPullRequest>,
+    #[allow(dead_code)]
     pub size: u32,
+    #[allow(dead_code)]
     pub limit: u32,
     #[serde(rename = "isLastPage")]
+    #[allow(dead_code)]
     pub is_last_page: bool,
+    #[allow(dead_code)]
     pub start: u32,
 }
 

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -27,6 +27,7 @@ pub fn cleanup_test_env(temp_dir: TempDir) {
 }
 
 /// Create a test configuration file
+#[allow(dead_code)]
 pub fn create_test_config(dir: &std::path::Path, repo_url: &str, main_branch: &str) -> PathBuf {
     let config_content = format!(
         r#"repositoryUrl: {}
@@ -47,11 +48,13 @@ hooks:
 }
 
 /// Verify that a directory contains a git repository
+#[allow(dead_code)]
 pub fn is_git_repo(dir: &std::path::Path) -> bool {
     dir.join(".git").exists()
 }
 
 /// Get the current git branch name from a repository
+#[allow(dead_code)]
 pub fn get_current_branch(repo_dir: &std::path::Path) -> Result<String, Box<dyn std::error::Error>> {
     use std::process::Command;
 
@@ -68,6 +71,7 @@ pub fn get_current_branch(repo_dir: &std::path::Path) -> Result<String, Box<dyn 
 }
 
 /// Check if git is available on the system
+#[allow(dead_code)]
 pub fn is_git_available() -> bool {
     std::process::Command::new("git")
         .arg("--version")


### PR DESCRIPTION
## Summary
- Fixed all compiler warnings in the codebase
- Added `#[allow(dead_code)]` annotations where appropriate
- Ensures clean builds for both debug and release modes

## Changes
- Added `#[allow(dead_code)]` to unused fields in `BitbucketDataCenterPullRequestsResponse` struct that are part of the API response but not currently used
- Added `#[allow(dead_code)]` to unused test utility functions that may be used in future tests

## Test plan
- [x] Run `cargo build` - no warnings
- [x] Run `cargo build --release` - no warnings  
- [x] Run `cargo test` - all tests pass without warnings