### PR TITLE
refactor: replace table display with hierarchical format in gwt list

### DIFF
--- a/src/commands/list_helpers.rs
+++ b/src/commands/list_helpers.rs
@@ -143,12 +143,6 @@ fn extract_bitbucket_data_center_url(pr: &bitbucket_data_center_api::BitbucketDa
     format!("PR #{}", pr.id)
 }
 
-pub fn format_pr_display(pr_info: Option<PullRequestInfo>) -> (String, String) {
-    match pr_info {
-        Some(info) => (format!("{} ({})", info.url, info.status), info.title),
-        None => ("-".to_string(), String::new()),
-    }
-}
 
 pub fn clean_branch_name(branch: &str) -> String {
     if branch.starts_with("refs/heads/") {


### PR DESCRIPTION
## Summary
- Replaced tabled dependency with custom hierarchical display format
- Each worktree now displays on 1-3 lines for better readability
- Added semantic color coding for improved visual scanning

## Changes
- **Removed table formatting**: No more fixed-width columns that truncate long content
- **Hierarchical display**: 
  - Branch name on first line (cyan)
  - PR URL with status on second line (blue/underlined URL, colored status)
  - PR title on third line (dimmed gray)
- **Color-coded statuses**: open (green), closed (red), merged (green), draft (yellow)
- **Better space utilization**: Long branch names and titles no longer get truncated

## Example Output
```
Local Worktrees:

main

feature/IP-3026010-fix-circular-dependency-between-database-commons-and-commons
  https://git.aut.valmet.com/projects/INSIGHT/repos/insight-ui/pull-requests/1562 (open)
  Feature/IP-3026 fix circular dependency between database commons and commons

gwt-list-update
```

## Test Plan
- [x] Build project with `cargo build`
- [x] Test with `gwt list` command
- [x] Verify colors display correctly
- [x] Test with worktrees that have and don't have PRs
- [x] Verify long branch names and titles display properly