### PR TITLE
fix: add Rust coverage files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,11 @@ coverage
 # nyc test coverage
 .nyc_output
 
+# Rust coverage files
+tarpaulin-report.html
+*.profraw
+target/tarpaulin/
+
 # Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ignore list to exclude Rust coverage reports and related files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->