### PR TITLE
yaml to jsonc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,7 +149,7 @@ Temporary Items
 .apdisk
 
 # Git worktree configuration
-git-worktree-config.yaml
+git-worktree-config.jsonc
 
 # Test directories
 test-temp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ This project is a **single Rust binary** that provides git worktree management f
 
 ## Hooks System
 
-The project includes a flexible hooks system that allows users to run custom commands after various worktree operations. Hooks are defined in the `git-worktree-config.yaml` file and support variable substitution.
+The project includes a flexible hooks system that allows users to run custom commands after various worktree operations. Hooks are defined in the `git-worktree-config.jsonc` file and support variable substitution.
 
 ### Available Hooks
 
@@ -86,28 +86,34 @@ Hooks support the following variables:
 
 ### Default Configuration
 
-When `gwtinit` creates a new project, it generates a `git-worktree-config.yaml` with all hooks **commented out by default**:
+When `gwt init` creates a new project, it generates a `git-worktree-config.jsonc` with empty hooks arrays by default:
 
-```yaml
-hooks:
-  postAdd:
-    - "# npm install"
-  postRemove:
-    - "# echo 'Removed worktree for branch ${branchName}'"
+```jsonc
+{
+  "hooks": {
+    "postAdd": [],
+    "postRemove": []
+  }
+}
 ```
 
 ### Active Configuration Example
 
-To enable hooks, simply remove the `#` comments:
+To enable hooks, add commands to the arrays:
 
-```yaml
-hooks:
-  postAdd:
-    - "echo 'Created worktree for ${branchName} at ${worktreePath}'"
-    - "npm install"
-    - "npm run init"
-  postRemove:
-    - "echo 'Removed worktree for branch ${branchName}'"
+```jsonc
+{
+  "hooks": {
+    "postAdd": [
+      "echo 'Created worktree for ${branchName} at ${worktreePath}'",
+      "npm install",
+      "npm run init"
+    ],
+    "postRemove": [
+      "echo 'Removed worktree for branch ${branchName}'"
+    ]
+  }
+}
 ```
 
 ### Hook Behavior
@@ -116,26 +122,31 @@ hooks:
 - **Execution context**: 
   - `postAdd`: Execute in the worktree directory
   - `postRemove`: Execute in the project root directory
-- **Comment handling**: Lines starting with `#` are automatically skipped
+- **Comment handling**: Use JSONC comments (`//` or `/* */`) outside of strings
 - **Error handling**: Failed hooks show warnings but don't stop execution
 - **Sequential execution**: Hooks run in the order they're defined
 - **Environment**: Hooks inherit the current environment with `FORCE_COLOR: '1'` for colored output
 
 ### Common Hook Patterns
 
-```yaml
-hooks:
-  postAdd:
-    - "npm install"                    # Install dependencies
-    - "npm run build"                  # Build project
-    - "code ."                         # Open in VS Code
-  postRemove:
-    - "echo 'Cleaned up ${branchName}'" # Log cleanup
+```jsonc
+{
+  "hooks": {
+    "postAdd": [
+      "npm install",                    // Install dependencies
+      "npm run build",                  // Build project
+      "code ."                          // Open in VS Code
+    ],
+    "postRemove": [
+      "echo 'Cleaned up ${branchName}'"  // Log cleanup
+    ]
+  }
+}
 ```
 
 ### Troubleshooting Hooks
 
-- **Hook not executing**: Check if the line starts with `#` (commented out)
+- **Hook not executing**: Check that the hook command is in the array
 - **No output visible**: Hooks use real-time streaming - output should appear immediately
 - **Hook fails**: Check the command syntax and file permissions
 - **Variable not substituted**: Ensure correct syntax: `${branchName}` or `${worktreePath}`
@@ -148,7 +159,7 @@ hooks:
    - ✅ Clones repository with **real-time streaming output** (major improvement!)
    - ✅ Detects the default branch name
    - ✅ Renames the cloned directory to match the branch name
-   - ✅ Creates `git-worktree-config.yaml` with repository metadata
+   - ✅ Creates `git-worktree-config.jsonc` with repository metadata
 
 2. **`gwt list`**: Display all worktrees in a formatted table ✅
    - ✅ Finds worktrees in project directory

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-worktree-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Mikko Kohtala"]
 description = "A tool for managing git worktrees efficiently"
@@ -13,7 +13,7 @@ path = "src/main.rs"
 clap = { version = "4.5", features = ["derive", "cargo", "env"] }
 clap_complete = "4.5"
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
+json5 = "0.4"
 serde_json = "1.0"
 colored = "3.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ gwt init https://bitbucket.company.com/scm/proj/repo.git --provider bitbucket-da
 
 # This creates:
 # - main/ directory (or master/ based on default branch)
-# - git-worktree-config.yaml (project metadata with provider info)
+# - git-worktree-config.jsonc (project metadata with provider info)
 # You'll see git clone progress in real-time!
 ```
 
@@ -205,7 +205,7 @@ Git worktree scripts support **hooks** - custom commands that run automatically 
 
 ### Quick Setup
 ```bash
-# After gwt init, edit git-worktree-config.yaml
+# After gwt init, edit git-worktree-config.jsonc
 hooks:
   postAdd:
     - "npm install"      # Auto-install deps in new worktrees
@@ -217,7 +217,7 @@ hooks:
 # Initialize project (creates config with hook examples)
 gwt init git@github.com:company/web-app.git
 
-# Edit git-worktree-config.yaml to enable hooks:
+# Edit git-worktree-config.jsonc to enable hooks:
 # hooks:
 #   postAdd:
 #     - "npm install"    # Remove # to enable

--- a/src/bitbucket_auth.rs
+++ b/src/bitbucket_auth.rs
@@ -67,7 +67,7 @@ pub fn get_auth_from_config() -> Result<(String, String, Option<String>)> {
     use crate::config::GitWorktreeConfig;
 
     let (_, config) =
-        GitWorktreeConfig::find_config()?.ok_or_else(|| Error::config("No git-worktree-config.yaml found"))?;
+        GitWorktreeConfig::find_config()?.ok_or_else(|| Error::config("No git-worktree-config.jsonc found"))?;
 
     if !config.repository_url.contains("bitbucket.org") {
         return Err(Error::provider("This is not a Bitbucket repository"));

--- a/src/bitbucket_data_center_auth.rs
+++ b/src/bitbucket_data_center_auth.rs
@@ -64,7 +64,7 @@ pub fn get_auth_from_config() -> Result<(String, String, String)> {
     use crate::github;
 
     let (_, config) =
-        GitWorktreeConfig::find_config()?.ok_or_else(|| Error::config("No git-worktree-config.yaml found"))?;
+        GitWorktreeConfig::find_config()?.ok_or_else(|| Error::config("No git-worktree-config.jsonc found"))?;
 
     // Check sourceControl field instead of URL pattern
     if config.source_control != "bitbucket-data-center" {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -104,6 +104,9 @@ pub enum Commands {
     Remove {
         /// Branch name to remove (current worktree if not specified)
         branch_name: Option<String>,
+        /// Skip confirmation prompts
+        #[arg(short, long)]
+        force: bool,
     },
 
     /// Manage authentication for external services

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -110,7 +110,7 @@ fn determine_paths(branch_name: &str) -> Result<(PathBuf, PathBuf, PathBuf)> {
 }
 
 fn get_main_branch(project_root: &Path) -> Result<String> {
-    let config_path = project_root.join("git-worktree-config.yaml");
+    let config_path = project_root.join("git-worktree-config.jsonc");
     if config_path.exists() {
         let config = GitWorktreeConfig::load(&config_path)?;
         Ok(config.main_branch)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -31,4 +31,4 @@ pub const GIT_EXTENSION: &str = ".git";
 
 /// Configuration file
 #[allow(dead_code)]
-pub const CONFIG_FILE_NAME: &str = "git-worktree-config.yaml";
+pub const CONFIG_FILE_NAME: &str = "git-worktree-config.jsonc";

--- a/src/core/project.rs
+++ b/src/core/project.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 /// Represents a git worktree project with its root and git directory
 #[derive(Debug, Clone)]
 pub struct Project {
-    /// The root directory containing git-worktree-config.yaml
+    /// The root directory containing git-worktree-config.jsonc
     pub root: PathBuf,
     /// The .git directory path
     pub git_dir: PathBuf,
@@ -37,7 +37,7 @@ impl Project {
     }
 }
 
-/// Find the project root containing git-worktree-config.yaml
+/// Find the project root containing git-worktree-config.jsonc
 pub fn find_project_root() -> Result<PathBuf> {
     let current_dir = std::env::current_dir().map_err(Error::Io)?;
     find_project_root_from(&current_dir)
@@ -48,7 +48,7 @@ pub fn find_project_root_from(start_path: &Path) -> Result<PathBuf> {
     let mut search_path = start_path.to_path_buf();
 
     loop {
-        if search_path.join("git-worktree-config.yaml").exists() {
+        if search_path.join("git-worktree-config.jsonc").exists() {
             return Ok(search_path);
         }
 
@@ -60,7 +60,7 @@ pub fn find_project_root_from(start_path: &Path) -> Result<PathBuf> {
     // Check if we're in a git repository but missing config
     if let Ok(Some(_)) = crate::git::get_git_root() {
         Err(Error::Other(
-            "Found git repository but no git-worktree-config.yaml. This doesn't appear to be a worktree project."
+            "Found git repository but no git-worktree-config.jsonc. This doesn't appear to be a worktree project."
                 .to_string(),
         ))
     } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -108,8 +108,8 @@ impl Error {
 }
 
 // Helper implementations for common conversions
-impl From<serde_yaml::Error> for Error {
-    fn from(err: serde_yaml::Error) -> Self {
+impl From<json5::Error> for Error {
+    fn from(err: json5::Error) -> Self {
         Error::Config(err.to_string())
     }
 }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -38,12 +38,6 @@ pub fn execute_hooks(hook_type: &str, working_directory: &Path, variables: &[(&s
     println!("{}", format!("🪝 Running {} hooks...", hook_type).cyan());
 
     for hook in hook_commands {
-        // Skip commented lines
-        if hook.trim().starts_with('#') {
-            println!("   {}", format!("Skipping commented hook: {}", hook).yellow());
-            continue;
-        }
-
         // Replace variables in the hook command
         let mut command = hook.clone();
         for (var_name, var_value) in variables {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ fn main() -> Result<()> {
         Commands::List { local } => {
             list::run(local)?;
         }
-        Commands::Remove { branch_name } => {
-            remove::run(branch_name.as_deref())?;
+        Commands::Remove { branch_name, force } => {
+            remove::run(branch_name.as_deref(), force)?;
         }
         Commands::Auth { action } => match action {
             AuthAction::Github => {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -30,7 +30,7 @@ fn test_gwt_init_with_valid_repo() {
         .stdout(predicate::str::contains("✓ Config saved to:"));
 
     // Check that files were created
-    let config_path = temp_path.join("git-worktree-config.yaml");
+    let config_path = temp_path.join("git-worktree-config.jsonc");
     assert!(config_path.exists(), "Config file should be created");
 
     // Check that the main branch directory was created
@@ -52,10 +52,10 @@ fn test_gwt_init_with_valid_repo() {
 
     // Verify config file content
     let config_content = fs::read_to_string(&config_path).unwrap();
-    assert!(config_content.contains("repositoryUrl: https://github.com/pitkane/git-worktree-cli.git"));
-    assert!(config_content.contains("mainBranch:"));
-    assert!(config_content.contains("createdAt:"));
-    assert!(config_content.contains("hooks:"));
+    assert!(config_content.contains("\"repositoryUrl\": \"https://github.com/pitkane/git-worktree-cli.git\""));
+    assert!(config_content.contains("\"mainBranch\":"));
+    assert!(config_content.contains("\"createdAt\":"));
+    assert!(config_content.contains("\"hooks\":"));
 
     cleanup_test_env(temp_dir);
 }
@@ -74,7 +74,7 @@ fn test_gwt_init_with_invalid_repo() {
     cmd.assert().failure();
 
     // Config file should not be created
-    let config_path = temp_path.join("git-worktree-config.yaml");
+    let config_path = temp_path.join("git-worktree-config.jsonc");
     assert!(!config_path.exists(), "Config file should not be created on failure");
 
     cleanup_test_env(temp_dir);

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -30,19 +30,20 @@ pub fn cleanup_test_env(temp_dir: TempDir) {
 #[allow(dead_code)]
 pub fn create_test_config(dir: &std::path::Path, repo_url: &str, main_branch: &str) -> PathBuf {
     let config_content = format!(
-        r#"repositoryUrl: {}
-mainBranch: {}
-createdAt: 2025-06-25T17:25:28.766876Z
-hooks:
-  postAdd:
-  - '# npm install'
-  postRemove:
-  - '# echo ''Removed worktree for branch ${{branchName}}'''
-"#,
+        r#"{{
+  "repositoryUrl": "{}",
+  "mainBranch": "{}",
+  "createdAt": "2025-06-25T17:25:28.766876Z",
+  "sourceControl": "github",
+  "hooks": {{
+    "postAdd": [],
+    "postRemove": []
+  }}
+}}"#,
         repo_url, main_branch
     );
 
-    let config_path = dir.join("git-worktree-config.yaml");
+    let config_path = dir.join("git-worktree-config.jsonc");
     fs::write(&config_path, config_content).expect("Failed to write test config");
     config_path
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --force (-f) to remove to skip confirmations and optionally force branch deletion.

- Refactor
  - Migrated configuration to JSONC; config file is now git-worktree-config.jsonc with empty default hook arrays.
  - Hooks no longer ignore lines starting with “#”; all listed commands are executed.

- Documentation
  - Updated all examples and guidance to JSONC syntax and filenames.

- Chores
  - Bumped version to 0.2.0.
  - Updated .gitignore to the new config filename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->