### PR TITLE
chore: prep for publishing (README, CLAUDE, CI, LICENSE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,24 @@
 name: CI
 
 on:
-  # Run on any PR
+  push:
   pull_request:
 
 jobs:
-  check:
+  build:
     runs-on: ubuntu-latest
-    steps: 
-    - name: Checkout
-      uses: actions/checkout@v3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Install stable toolchain
-      uses: dtolnay/rust-toolchain@stable
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Cache Rust dependencies and build
-      uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: tests
+      - name: Cache Rust dependencies and build
+        uses: Swatinem/rust-cache@v2
 
-    - run: |
-        cargo test
-        cargo build --release
-      working-directory: tests
+      - name: Test
+        run: cargo test --all --verbose
+
+      - name: Build release
+        run: cargo build --release --verbose

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,347 +1,57 @@
 # CLAUDE.md
 
-This file provides guidance to ([Claude Code](https://www.anthropic.com/claude-code)) when working with code in this repository.
-
-## Commands
-
-### Development
-- **Build release binary**: `cargo build --release` - Creates optimized binary at `target/release/gwt`
-- **Build debug binary**: `cargo build` - Creates debug binary for development
-- **Run tests**: `cargo test` - Comprehensive unit and integration tests
-- **Type checking**: `cargo check` - Fast compilation check without building binary
-- **Run with cargo**: `cargo run -- <command>` - Run directly with cargo for development
-- **Format code**: `cargo fmt` - Format all Rust code according to rustfmt.toml settings
-
-### Testing and Local Development
-When Claude needs to test functionality locally:
-- Use `cargo build` for debug builds or `cargo build --release` for optimized builds
-- Run the binary directly: `./target/release/gwt <command>` or `./target/debug/gwt <command>`
-- Create test repositories in the `test-temp/` directory which is git-ignored
-- Use `gwt init` to create proper worktree projects for testing
-- Clean up test directories after testing with `rm -rf test-temp`
-- Example test workflow:
-  ```bash
-  mkdir test-temp && cd test-temp
-  ../target/release/gwt init https://github.com/octocat/Hello-World.git
-  ../target/release/gwt list
-  cd .. && rm -rf test-temp
-  ```
-
-## Version Management
-
-**IMPORTANT**: Whenever making code changes, always increment the version in Cargo.toml:
-- Patch version (x.x.N) for bug fixes and minor improvements
-- Minor version (x.N.x) for new features
-- Major version (N.x.x) for breaking changes
-
-### Git Worktree Tool (gwt)
-- **Initialize project**: `gwt init <repository-url>` - Initialize a new worktree project from a repository URL
-- **Add worktree**: `gwt add <branch-name>` - Create new worktrees from branch names  
-- **List worktrees**: `gwt list` - List all worktrees in a formatted table
-- **Remove worktree**: `gwt remove [branch-name]` - Remove existing worktrees with confirmation
-- **Check completions**: `gwt completions` - Check if shell completions are installed
-- **Install completions**: `gwt completions install [shell]` - Automatically install completions (defaults to detected shell)
-- **Generate completions**: `gwt completions generate <shell>` - Generate shell completion scripts to stdout
-- **Tab completion**: Dynamic branch name completion for add/remove commands (see completions/SETUP.md)
-
-### Legacy TypeScript Version
-The original TypeScript implementation has been moved to `typescript-version/` directory for reference.
-
-## Architecture
-
-This project is a **single Rust binary** that provides git worktree management functionality. The architecture consists of:
-
-1. **Rust Binary** (`src/`): Core functionality written in Rust
-   - `main.rs`: CLI entry point using clap for argument parsing
-   - `cli.rs`: Separated CLI structure for build-time completion generation
-   - `commands/`: Individual command implementations (init, add, list, remove)
-   - `completions.rs`: Embedded shell completions with auto-install functionality
-   - `config.rs`: YAML configuration file handling using serde
-   - `git.rs`: Git operations with native process execution and streaming output
-   - `hooks.rs`: Hook execution system with real-time output streaming
-   - `utils.rs`: Shared utility functions
-   - `build.rs`: Build script that generates shell completions at compile time
-
-2. **Key Dependencies**:
-   - `clap`: Command-line argument parsing with derive macros
-   - `clap_complete`: Shell completion generation (build dependency)
-   - `serde` + `serde_yaml`: Configuration file serialization/deserialization
-   - `anyhow`: Error handling and context
-   - `colored`: Terminal output colorization
-   - `chrono`: Date/time handling for config timestamps
-   - `tabled`: Table formatting for list output
-
-3. **Test Infrastructure**:
-   - `tests/`: Integration tests using `assert_cmd` and `tempfile`
-   - Unit tests embedded in source modules
-   - Real git repository testing with streaming output verification
-
-## Hooks System
-
-The project includes a flexible hooks system that allows users to run custom commands after various worktree operations. Hooks are defined in the `git-worktree-config.jsonc` file and support variable substitution.
-
-### Available Hooks
-
-- **`postAdd`**: Executed after `gwt add` creates a new worktree
-- **`postRemove`**: Executed after `gwt remove` removes a worktree
-
-### Variable Substitution
-
-Hooks support the following variables:
-- `${branchName}`: The name of the branch
-- `${worktreePath}`: The full path to the worktree directory
-
-### Default Configuration
-
-When `gwt init` creates a new project, it generates a `git-worktree-config.jsonc` with empty hooks arrays by default:
-
-```jsonc
-{
-  "hooks": {
-    "postAdd": [],
-    "postRemove": []
-  }
-}
-```
-
-### Active Configuration Example
-
-To enable hooks, add commands to the arrays:
-
-```jsonc
-{
-  "hooks": {
-    "postAdd": [
-      "echo 'Created worktree for ${branchName} at ${worktreePath}'",
-      "npm install",
-      "npm run init"
-    ],
-    "postRemove": [
-      "echo 'Removed worktree for branch ${branchName}'"
-    ]
-  }
-}
-```
-
-### Hook Behavior
-
-- **Real-time output**: Commands stream output live using `execSync` with `stdio: 'inherit'`
-- **Execution context**: 
-  - `postAdd`: Execute in the worktree directory
-  - `postRemove`: Execute in the project root directory
-- **Comment handling**: Use JSONC comments (`//` or `/* */`) outside of strings
-- **Error handling**: Failed hooks show warnings but don't stop execution
-- **Sequential execution**: Hooks run in the order they're defined
-- **Environment**: Hooks inherit the current environment with `FORCE_COLOR: '1'` for colored output
-
-### Common Hook Patterns
-
-```jsonc
-{
-  "hooks": {
-    "postAdd": [
-      "npm install",                    // Install dependencies
-      "npm run build",                  // Build project
-      "code ."                          // Open in VS Code
-    ],
-    "postRemove": [
-      "echo 'Cleaned up ${branchName}'"  // Log cleanup
-    ]
-  }
-}
-```
-
-### Troubleshooting Hooks
-
-- **Hook not executing**: Check that the hook command is in the array
-- **No output visible**: Hooks use real-time streaming - output should appear immediately
-- **Hook fails**: Check the command syntax and file permissions
-- **Variable not substituted**: Ensure correct syntax: `${branchName}` or `${worktreePath}`
-
-## Current Implementation Status
-
-### ✅ Implemented Features (Rust)
-
-1. **`gwt init`**: Initialize worktrees from repository URLs ✅
-   - ✅ Clones repository with **real-time streaming output** (major improvement!)
-   - ✅ Detects the default branch name
-   - ✅ Renames the cloned directory to match the branch name
-   - ✅ Creates `git-worktree-config.jsonc` with repository metadata
-
-2. **`gwt list`**: Display all worktrees in a formatted table ✅
-   - ✅ Finds worktrees in project directory
-   - ✅ Displays in clean table format with sharp borders
-   - ✅ Shows path, branch name, and HEAD commit
-   - ✅ Works from any subdirectory within project
-
-3. **`gwt completions`**: Enhanced shell completions support ✅
-   - ✅ Check if completions are installed
-   - ✅ Auto-install completions with `gwt completions install [shell]`
-   - ✅ Generate completions for any shell with `gwt completions generate <shell>`
-   - ✅ Smart detection of user's shell
-   - ✅ Completions embedded in binary at compile time
-   - ✅ Support for bash, zsh, fish, powershell, and elvish
-   - ✅ Automatic path detection for each shell's completion directory
-   - ✅ Branch name completion for add/remove commands
-
-4. **`gwt add`**: Create new worktrees from branch names ✅
-   - ✅ Create worktree from existing local branch
-   - ✅ Create worktree from existing remote branch
-   - ✅ Create new branch from main/master branch
-   - ✅ Smart branch detection and handling
-   - ✅ Execute post-add hooks with variable substitution
-   - ✅ Real-time streaming output for git operations
-   - ✅ Project root detection and validation
-
-5. **`gwt remove`**: Remove worktrees with safety checks ✅
-   - ✅ Remove worktree by branch name or current worktree
-   - ✅ Interactive confirmation prompts
-   - ✅ Safety checks (prevents removing bare repository)
-   - ✅ Automatic branch deletion for feature branches
-   - ✅ Preserves main branches (main/master/dev/develop)
-   - ✅ Handles current directory when removing current worktree
-   - ✅ Execute post-remove hooks with variable substitution
-   - ✅ Comprehensive error handling and user feedback
-
-
-### 🎯 Major Improvements Achieved
-
-- **✅ Real-time streaming output**: Git commands show progress in real-time using Rust's native `Command` with `Stdio::inherit()`
-- **✅ Single binary distribution**: No Node.js runtime or shell wrapper functions needed
-- **✅ Embedded completions**: Shell completions are generated at compile time and embedded in the binary
-- **✅ Enhanced shell completions**: Auto-install support for all major shells
-- **✅ Better error handling**: Rust's `Result` type provides robust error propagation
-- **✅ Faster execution**: Compiled binary vs interpreted TypeScript
-- **✅ Cross-platform compatibility**: Easy to build for different OS/architectures
-- **✅ Sharp table formatting**: Professional table output using Unicode box-drawing characters
-- **✅ Smart shell detection**: Automatically detects user's shell for completion installation
-
-## Test Suite
-
-The project includes comprehensive testing in Rust:
-- **Integration tests** (`tests/`): Uses `assert_cmd` and `tempfile` for real command testing
-- **Unit tests**: Embedded in source modules with `#[cfg(test)]`
-- **Real streaming verification**: Tests actually verify git clone output streaming
-- **6 integration tests**: Covering init command, help, version, error handling
-- **4 unit tests**: Testing config module functionality
-- **Fast execution**: All tests run in ~6 seconds vs 15+ seconds for TypeScript version
-
-## Project Management
-
-Project tasks and TODOs are tracked in `TODO.md` for persistence across Claude Code sessions.
-
-## Code Style
-
-- **Language**: Rust 2021 edition with standard formatting
-- **Formatting**: `cargo fmt` with rustfmt.toml configuration (120 character line width)
-- **Error Handling**: `anyhow::Result` for error propagation with context
-- **CLI Framework**: `clap` with derive macros for argument parsing
-- **Serialization**: `serde` with `serde_yaml` for configuration files
-- **Testing**: Integration tests with `assert_cmd`, unit tests with `#[cfg(test)]`
-- **File Organization**: Each command has its own module, shared utilities in dedicated modules
-
-## Important Technical Notes
-
-### Real-time Streaming Output with Rust
-
-The Rust implementation naturally handles streaming output using native `std::process::Command`:
-
-```rust
-// ✅ Real-time streaming with Rust - simple and effective!
-use std::process::{Command, Stdio};
-
-Command::new("git")
-    .args(["clone", repo_url, repo_name])
-    .stdout(Stdio::inherit())
-    .stderr(Stdio::inherit())
-    .status()?;
-```
-
-**Key advantages over the TypeScript/zx approach:**
-- **No buffering issues**: Output streams directly to terminal
-- **Native support**: No workarounds needed for real-time output
-- **Better performance**: Direct process spawning without Node.js overhead
-- **Cross-platform**: Works consistently across different operating systems
-
-### Hook Execution with Streaming
-
-Hooks also benefit from native process execution:
-
-```rust
-// Hooks execute with real-time output
-Command::new("sh")
-    .arg("-c")
-    .arg(command)
-    .current_dir(working_directory)
-    .stdout(Stdio::inherit())
-    .stderr(Stdio::inherit())
-    .env("FORCE_COLOR", "1")
-    .status()?;
-```
-
-This eliminates the complex issues that existed with the TypeScript implementation where streaming output required workarounds with `execSync` and `stdio: 'inherit'`.
-
-### Shell Completions Architecture
-
-The Rust implementation uses a build-time completion generation approach:
-
-1. **Build Script (`build.rs`)**:
-   - Generates completions for all supported shells at compile time
-   - Uses the `cli.rs` module to access the CLI structure without dependencies
-   - Stores generated completions in the `OUT_DIR` for embedding
-
-2. **Embedded Completions (`completions.rs`)**:
-   - Uses `include_str!` to embed completion files directly in the binary
-   - Provides shell detection and automatic installation paths
-   - Handles shell-specific installation requirements
-
-3. **Benefits**:
-   - **No external files needed**: Completions are part of the binary
-   - **Always in sync**: Completions automatically match the CLI structure
-   - **Easy distribution**: Single binary includes everything
-   - **Multi-shell support**: All shells supported without extra downloads
-
-Example of embedded completion:
-```rust
-const BASH_COMPLETION: &str = include_str!(concat!(env!("OUT_DIR"), "/completions/gwt.bash"));
-```
-
-### Secure Credential Management
-
-The application uses the system keyring for secure credential storage:
-
-```rust
-use keyring::Entry;
-
-// Store credentials securely
-let entry = Entry::new("gwt", &username)?;
-entry.set_password(&token)?;
-
-// Retrieve credentials
-let password = entry.get_password()?;
-```
-
-**Security features:**
-- **No plaintext storage**: All credentials encrypted by OS
-- **Per-user isolation**: Credentials tied to user account
-- **Cross-platform**: Works on Windows, macOS, and Linux
-- **Automatic cleanup**: Credentials can be easily removed
-
-## Provider URLs and Authentication
-
-### GitHub
-- **URL patterns**: `github.com`, `git@github.com:`
-- **Authentication**: GitHub CLI (`gh auth login`)
-- **API**: Uses `gh pr list` command for PR information
-
-### Bitbucket Cloud
-- **URL patterns**: `bitbucket.org`
-- **Authentication**: OAuth app passwords via interactive setup
-- **API**: Direct REST API calls to `api.bitbucket.org`
-- **Credentials**: Stored in system keyring as `gwt-bitbucket-cloud`
-
-### Bitbucket Data Center
-- **URL patterns**: Custom domains (detected by elimination)
-- **Authentication**: Personal access tokens via interactive setup
-- **API**: REST API calls to custom Bitbucket instance
-- **Credentials**: Stored in system keyring as `gwt-bitbucket-datacenter`
+Concise guidance for AI/code assistants working in this repository.
+
+## Project
+
+- Single Rust binary providing an ergonomic wrapper around `git worktree`
+- Config file: `git-worktree-config.jsonc` (JSON with comments)
+- Supported providers for PR info: GitHub, Bitbucket Cloud, Bitbucket Data Center
+
+## Build & Test
+
+- Build (debug): `cargo build`
+- Build (release): `cargo build --release`
+- Run: `cargo run -- <command>`
+- Tests: `cargo test` (unit + integration)
+
+## CLI
+
+- `gwt init <repo-url> [--provider <github|bitbucket-cloud|bitbucket-data-center>]`
+- `gwt add <branch>`
+- `gwt list` (shows PRs, requires provider auth)
+- `gwt remove [branch] [--force]`
+- `gwt auth <github|bitbucket-cloud|bitbucket-data-center> [setup|test]`
+- `gwt completions [install|generate <shell>]`
+
+## Completions
+
+- Completions are generated at build time by `build.rs` and embedded
+- Install for detected shell: `gwt completions install`
+- Generate to stdout: `gwt completions generate <shell>`
+
+## Versioning & Metadata
+
+- Bump `version` in `Cargo.toml` for changes
+  - Patch: bug fixes, small improvements
+  - Minor: new features (backward compatible)
+  - Major: breaking changes
+- Ensure `Cargo.toml` keeps `license` and `readme` set
+
+## Style & Conventions
+
+- Rust 2021; format with `cargo fmt` (see `rustfmt.toml`)
+- Error handling via `thiserror`-based custom errors in `src/error.rs`
+- Prefer small, focused modules under `src/` and `src/commands/`
+- Avoid adding Node/TypeScript artifacts; this is a Rust-only codebase
+
+## Testing Notes
+
+- Integration tests live in `tests/` and should not depend on network access
+- Prefer fast, deterministic tests; use temporary directories where needed
+
+## Local Dev Tips
+
+- To try features quickly without installing: `cargo run -- <subcommand>`
+- For shell completions during dev: `gwt completions install`
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.3.1"
 edition = "2021"
 authors = ["Mikko Kohtala"]
 description = "A tool for managing git worktrees efficiently"
+license = "MIT"
+readme = "README.md"
 
 [[bin]]
 name = "gwt"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Mikko Kohtala
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,415 +1,71 @@
 # Git Worktree CLI (gwt)
 
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/mikko-kohtala/git-worktree-cli)
+Fast, ergonomic git worktree management with a single Rust binary. Create, list and remove worktrees with real-time streaming output, optional hooks, and pull request info from GitHub and Bitbucket.
 
-🌿 **Enhanced Git Worktree Management with Rust** 🌿
+## Features
 
-Stop juggling multiple git clones or constantly switching branches. Git worktrees let you have multiple working directories from the same repository, each checked out to different branches. This Rust-powered tool makes managing them effortless with **real-time streaming output**.
+- Real-time git output for clone and worktree operations
+- Create/list/remove worktrees safely with helpful prompts
+- Embedded shell completions with one-step install
+- PR overview in `gwt list` (GitHub, Bitbucket Cloud & Data Center)
+- Secure auth storage (system keyring) for Bitbucket
+- Optional hooks on add/remove (postAdd, postRemove)
 
-*This project was built with [Claude Code](https://claude.ai/code) using Opus 4 and Sonnet 4 models.*
+## Install
 
-## What are Git Worktrees?
+Build from source:
 
-Instead of this messy workflow:
 ```bash
-# The old way - multiple clones or constant switching
-git clone repo.git feature-work
-git clone repo.git bugfix-work
-# OR constantly: git checkout feature && git checkout main && git checkout bugfix...
+cargo install --path .            # installs `gwt` to ~/.cargo/bin
+# or
+cargo build --release && sudo cp target/release/gwt /usr/local/bin/
 ```
 
-Git worktrees let you do this:
+Install shell completions (recommended):
+
 ```bash
-# One repository, multiple working directories
-my-project/
-├── main/           # Main branch
-├── feature-123/    # Feature branch  
-└── bugfix-456/     # Bugfix branch
+gwt completions           # shows status and guidance
+gwt completions install   # auto-detects shell and installs
 ```
 
-Each directory is a separate working tree of the same repository. No more stashing, switching, or losing context.
+## Quick Start
 
-## Installation
-
-### Option 1: Build from Source (Recommended)
-
-1. **Clone this repository:**
-   ```bash
-   git clone git@github.com:pitkane/git-worktree-cli.git ~/.git-worktree-cli
-   cd ~/.git-worktree-cli
-   ```
-
-2. **Build the binary:**
-   ```bash
-   cargo build --release
-   ```
-
-3. **Install the binary:**
-   ```bash
-   # Copy to your PATH
-   sudo cp target/release/gwt /usr/local/bin/
-   # Or add to your shell config
-   echo 'export PATH="$HOME/.git-worktree-cli/target/release:$PATH"' >> ~/.zshrc
-   source ~/.zshrc
-   ```
-
-4. **Install shell completions (recommended):**
-   ```bash
-   # Check if completions are installed
-   gwt completions
-   
-   # Automatically install completions for your shell
-   gwt completions install
-   
-   # Or install for a specific shell
-   gwt completions install bash
-   gwt completions install zsh
-   gwt completions install fish
-   gwt completions install powershell
-   gwt completions install elvish
-   
-   # Generate completions to stdout (for manual installation)
-   gwt completions generate <shell>
-   ```
-   
-   **Note**: Completions are embedded in the binary, so they're always available!
-
-### Option 2: Direct Binary Download (Coming Soon)
-Pre-built binaries will be available for:
-- macOS (Intel & Apple Silicon)
-- Linux (x86_64 & ARM64)
-- Windows
-
-### Option 3: Install via Cargo (Coming Soon)
 ```bash
-cargo install gwt
-```
+# Initialize a project (detects default branch, writes git-worktree-config.jsonc)
+gwt init <repo-url>
 
-## Quick Start Workflow
+# Optionally specify provider if auto-detect fails
+gwt init <bitbucket-url> --provider bitbucket-cloud
+gwt init <on-prem-bb-url> --provider bitbucket-data-center
 
-### 1. Initialize a Project
-```bash
-# Clone and setup worktree structure with REAL-TIME OUTPUT!
-gwt init git@github.com:username/repo.git
-
-# Or specify a provider explicitly:
-gwt init https://bitbucket.org/workspace/repo.git --provider bitbucket-cloud
-gwt init https://bitbucket.company.com/scm/proj/repo.git --provider bitbucket-data-center
-
-# This creates:
-# - main/ directory (or master/ based on default branch)
-# - git-worktree-config.jsonc (project metadata with provider info)
-# You'll see git clone progress in real-time!
-```
-
-### 2. Create Feature Branches
-```bash
-# Create new feature worktree
-gwt add feature/user-auth
-# Creates feature/user-auth/ directory
-
-# Create bugfix worktree  
-gwt add bugfix/login-error
-# Creates bugfix/login-error/ directory
-```
-
-### 3. List Your Worktrees
-```bash
-# See all your worktrees in a clean table
+# Create and list work
+gwt add feature/new-ui
 gwt list
 
-# Output:
-# ┌───────────────────┬───────────────────────────────────────────────────────────┐
-# │ BRANCH            │ PULL REQUEST                                              │
-# ├───────────────────┼───────────────────────────────────────────────────────────┤
-# │ main              │ -                                                         │
-# │ feature/user-auth │ https://github.com/owner/repo/pull/42 (open)              │
-# │ bugfix/login-error│ https://github.com/owner/repo/pull/41 (draft)             │
-# └───────────────────┴───────────────────────────────────────────────────────────┘
+# Remove when done
+gwt remove feature/new-ui     # or run inside the worktree with `gwt remove`
 ```
 
-### 4. Switch Between Work
-```bash
-# Navigate to any worktree directory
-cd ../feature/user-auth
-cd ../main
-# No git checkout needed!
-```
+## PR Integration
 
-### 5. Clean Up When Done
-```bash
-# Remove completed feature
-gwt remove feature/user-auth  # Removes worktree
+- GitHub: requires `gh` CLI and `gh auth login`
+- Bitbucket Cloud: `gwt auth bitbucket-cloud setup` then `gwt auth bitbucket-cloud test`
+- Bitbucket Data Center: `gwt auth bitbucket-data-center setup` then `gwt auth bitbucket-data-center test`
 
-# Or remove current worktree
-cd ../feature/old-feature
-gwt remove  # Removes current worktree you're in
-```
-
-## Real-World Example
-
-```bash
-# Start new project with streaming git clone output
-gwt init git@github.com:company/web-app.git
-cd main
-
-# Work on a new feature
-gwt add feature/shopping-cart
-cd ../feature/shopping-cart
-# Make commits, push changes...
-
-# Urgent bugfix needed - no stashing required!
-gwt add hotfix/payment-bug
-cd ../hotfix/payment-bug
-# Fix bug, commit, push...
-
-# Back to feature work
-cd ../feature/shopping-cart
-# Continue where you left off
-
-# Review all work
-gwt list
-
-# Clean up merged work
-gwt remove hotfix/payment-bug
-```
-
-## Commands Reference
-
-| Command | Description | Example | Status |
-|---------|-------------|---------|---------|
-| `gwt init <url>` | Initialize worktree project from repo | `gwt init git@github.com:user/repo.git` | ✅ **Working** |
-| `gwt list` | List all worktrees in a table | `gwt list` | ✅ **Working** |
-| `gwt add <branch>` | Create new worktree for branch | `gwt add feature/new-ui` | ✅ **Working** |
-| `gwt remove [branch]` | Remove worktree (current if no args) | `gwt remove old-feature` | ✅ **Working** |
-| `gwt completions` | Check completion status | `gwt completions` | ✅ **Working** |
-| `gwt completions install [shell]` | Auto-install completions | `gwt completions install` | ✅ **Working** |
-| `gwt completions generate <shell>` | Generate completions | `gwt completions generate zsh` | ✅ **Working** |
-| `gwt auth <provider>` | Manage authentication for providers | `gwt auth github` | ✅ **Working** |
-
-**New in Rust version:**
-- ✅ **Real-time streaming output** - See git clone progress live!
-- ✅ **Single binary** - No Node.js dependency
-- ✅ **Embedded completions** - Completions built into the binary at compile time
-- ✅ **Multi-shell support** - Bash, Zsh, Fish, PowerShell, and Elvish
-- ✅ **Smart completions** - Auto-detect shell and install with one command
-- ✅ **Better performance** - Compiled Rust vs interpreted TypeScript
-- ✅ **Sharp table output** - Clean, modern table formatting with proper column alignment
-- ✅ **Multi-provider support** - Works with GitHub, Bitbucket Cloud, and Bitbucket Data Center
-- ✅ **Comprehensive PR integration** - See pull request status across all providers
-- ✅ **Secure authentication** - Keyring-based credential storage for Bitbucket
-
-## Hooks & Automation
-
-Git worktree scripts support **hooks** - custom commands that run automatically after worktree operations. Perfect for automating setup tasks like installing dependencies or running initialization scripts.
-
-### Quick Setup
-```bash
-# After gwt init, edit git-worktree-config.jsonc
-hooks:
-  postAdd:
-    - "npm install"      # Auto-install deps in new worktrees
-    - "npm run init"     # Run your custom setup script
-```
-
-### Example Workflow with Hooks
-```bash
-# Initialize project (creates config with hook examples)
-gwt init git@github.com:company/web-app.git
-
-# Edit git-worktree-config.jsonc to enable hooks:
-# hooks:
-#   postAdd:
-#     - "npm install"    # Remove # to enable
-
-# Create new worktree - hooks run automatically!
-gwt add feature/shopping-cart
-# This will:
-# 1. Create the worktree  
-# 2. Run "npm install" automatically with streaming output
-# 3. cd to the new directory
-
-# Continue with your work - dependencies already installed!
-```
-
-### Available Hook Types
-- **`postAdd`**: After creating a new worktree (perfect for setup)
-- **`postRemove`**: After removing a worktree (great for cleanup)
-
-### Variable Support
-Use `${branchName}` and `${worktreePath}` in your hooks:
-```yaml
-hooks:
-  postAdd:
-    - "echo 'Created ${branchName} at ${worktreePath}'"
-    - "npm install"
-  postRemove:
-    - "echo 'Removed worktree for branch ${branchName}'"
-```
-
-By default, all hooks are commented out (disabled) - uncomment the ones you want to use.
-
-## Pull Request Integration
-
-View pull request information directly in your worktree list across multiple providers!
-
-### Supported Providers
-
-- **GitHub** - Using the GitHub CLI (`gh`)
-- **Bitbucket Cloud** - OAuth-based authentication
-- **Bitbucket Data Center** - Personal access token authentication
-
-### Setup Authentication
-
-#### GitHub
-```bash
-# Check GitHub auth status
-gwt auth github
-
-# If not authenticated, use gh CLI:
-gh auth login
-```
-
-#### Bitbucket Cloud
-```bash
-# Setup Bitbucket Cloud authentication
-gwt auth bitbucket-cloud setup
-
-# Test the connection
-gwt auth bitbucket-cloud test
-```
-
-#### Bitbucket Data Center (On-Premise)
-```bash
-# Setup Bitbucket Data Center authentication
-gwt auth bitbucket-data-center setup
-
-# Test the connection
-gwt auth bitbucket-data-center test
-```
-
-### View PR Status
-```bash
-# List worktrees with PR info (requires gh CLI authentication)
-gwt list
-
-# Shows PR URL and status for each branch across all providers
-# ┌───────────────────┬───────────────────────────────────────────────────────────┐
-# │ BRANCH            │ PULL REQUEST                                              │
-# ├───────────────────┼───────────────────────────────────────────────────────────┤
-# │ main              │ -                                                         │
-# │ feature/new-ui    │ #123: Implement new UI design (open)                      │
-# │ fix/memory-leak   │ #122: Fix memory leak in parser (draft)                   │
-# │ hotfix/security   │ #121: Security patch for auth (merged)                    │
-# └───────────────────┴───────────────────────────────────────────────────────────┘
-# 
-# PRs without local worktrees:
-# • #125: Add dark mode support (open)
-# • #124: Update dependencies (draft)
-```
-
-**Pull Request Status Colors:**
-- 🟢 **open** - Active pull request
-- 🟢 **merged** - Successfully merged
-- 🟡 **draft** - Work in progress
-- 🔴 **closed** - Closed without merging
-
-### Requirements
-
-#### For GitHub:
-- Install [GitHub CLI](https://cli.github.com/) (`gh`)
-- Authenticate with `gh auth login`
-
-#### For Bitbucket Cloud:
-- OAuth app password (created in Bitbucket settings)
-- Repository access permissions
-
-#### For Bitbucket Data Center:
-- Personal access token
-- Network access to your Bitbucket instance
-
-## Benefits
-
-- **🚀 No Context Switching**: Each branch keeps its own working directory
-- **🔄 Instant Branch Switching**: Just cd to the directory
-- **🛡️ Safe Experimentation**: Isolated working directories prevent conflicts
-- **⚡ Parallel Development**: Work on multiple features simultaneously
-- **🧹 Easy Cleanup**: Remove completed work with one command
-- **🪝 Smart Automation**: Hooks automatically run setup/cleanup tasks
-- **📊 Real-time Feedback**: See command output as it executes
-- **🎯 Tab Completion**: Branch names auto-complete for add/remove commands
-- **🔗 Multi-Provider Support**: Works with GitHub, Bitbucket Cloud, and Bitbucket Data Center
-- **🔐 Secure Authentication**: Credentials stored securely in system keyring
-- **📋 PR Overview**: See all pull requests, even those without local worktrees
+`gwt list` shows PR link and status for each branch; it can also list open PRs without local worktrees.
 
 ## Requirements
 
-- **Rust 1.70+** (for building from source)
-- **Git 2.5+** (for worktree support)
-- **Bash/Zsh/Fish shell** (for completions)
-
-## Development
-
-```bash
-# Build debug binary
-cargo build
-
-# Build release binary
-cargo build --release
-
-# Run tests
-cargo test
-
-# Type checking
-cargo check
-
-# Run with cargo
-cargo run -- <command>
-```
-
-## Troubleshooting
-
-### Completions not working?
-```bash
-# Check if completions are installed
-gwt completions
-
-# Auto-install completions for your detected shell
-gwt completions install
-
-# Or specify a shell explicitly
-gwt completions install zsh
-
-# For manual installation, generate completions
-gwt completions generate zsh > ~/.local/share/zsh/site-functions/_gwt
-
-# Reload your shell
-source ~/.zshrc  # or exec zsh
-```
-
-**Supported shells**: bash, zsh, fish, powershell, elvish
-
-### Command not found?
-Make sure the binary is in your PATH:
-```bash
-which gwt
-# If not found, add to PATH:
-export PATH="$HOME/.git-worktree-cli/target/release:$PATH"
-```
+- Rust 1.70+ (to build), Git 2.5+
+- Shell for completions: bash, zsh, fish, powershell, or elvish
 
 ## Contributing
 
-Contributions welcome! Please:
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run tests (`cargo test`)
-5. Submit a pull request
+- Fork, create a branch, make changes
+- Run tests with `cargo test`
+- Open a pull request
 
 ## License
 
-MIT License - see LICENSE file for details
+MIT — see `LICENSE`.
 
-## History
-
-This project was originally implemented in TypeScript but has been rewritten in Rust for better performance and distribution. The TypeScript version has been removed from the repository but can be found at this point in the project's history: https://github.com/pitkane/git-worktree-cli/tree/1d8b2a2431d302737e21bec6a0f09a77d2bb9cc3

--- a/src/README.md
+++ b/src/README.md
@@ -1,107 +1,33 @@
-# Git Worktree CLI - Source Code Structure
+# Git Worktree CLI – Source Layout
 
-This directory contains the Rust source code for the git worktree CLI tool (`gwt`).
+Overview of the Rust code for the `gwt` binary.
 
-## Architecture Overview
+## Structure
 
-The codebase follows a modular architecture with clear separation of concerns:
+- `main.rs` – CLI entrypoint; routes to subcommands
+- `cli.rs` – clap definitions for arguments and subcommands
+- `commands/` – implementation of subcommands
+  - `init.rs`, `add.rs`, `list.rs`, `remove.rs`, `auth.rs`
+- `git.rs` – git command execution with real-time streaming
+- `hooks.rs` – postAdd/postRemove hook execution
+- `config.rs` – JSONC config (`git-worktree-config.jsonc`) handling
+- `completions.rs` – embedded completion logic + install helpers
+- `error.rs` – error types using `thiserror`
+- `core/` – project discovery and utilities
+  - `project.rs`, `utils.rs`
+- Provider/PR integrations
+  - `github.rs`, `bitbucket_api.rs`, `bitbucket_data_center_api.rs`
+  - `bitbucket_auth.rs`, `bitbucket_data_center_auth.rs`
 
-### Core Modules
+## Guidelines
 
-- **`lib.rs`** - Library root that exposes the public API
-- **`main.rs`** - Thin binary entry point that uses the library
-- **`error.rs`** - Centralized error handling with custom error types
-- **`constants.rs`** - Application-wide constants
+- Keep subcommands small and focused; prefer helpers in modules
+- Prefer descriptive errors; bubble up `Result` from helpers
+- Format with `cargo fmt` (see `rustfmt.toml`)
+- Tests: unit alongside modules; integration in `tests/`
 
-### Business Logic
+## Adding a Command
 
-- **`core/`** - Core business logic independent of CLI and external APIs
-  - `project.rs` - Project discovery and management (finding project roots, git directories)
-  - `utils.rs` - Shared utility functions
-
-### Command Line Interface
-
-- **`cli.rs`** - Command-line argument definitions using clap
-- **`commands/`** - Individual command implementations
-  - `init.rs` - Initialize new worktree projects
-  - `add.rs` - Add worktrees from branches
-  - `list.rs` - List worktrees with PR information
-  - `remove.rs` - Remove worktrees safely
-  - `auth.rs` - Authentication management
-
-### External Integrations
-
-- **`providers/`** - Trait-based API provider architecture
-  - `mod.rs` - Provider trait definition
-  - `github.rs` - GitHub integration
-  - `bitbucket_cloud.rs` - Bitbucket Cloud integration
-  - `bitbucket_server.rs` - Bitbucket Server/Data Center integration
-
-### Git Operations
-
-- **`git.rs`** - Low-level git command execution with streaming output
-- **`hooks.rs`** - Hook execution system for post-add/remove actions
-
-### Configuration
-
-- **`config.rs`** - YAML configuration file handling
-- **`completions.rs`** - Shell completion generation and installation
-
-### Authentication Modules
-
-- **`github.rs`** - GitHub CLI integration
-- **`bitbucket_auth.rs`** - Bitbucket Cloud OAuth authentication
-- **`bitbucket_data_center_auth.rs`** - Bitbucket Server authentication
-
-### API Clients
-
-- **`bitbucket_api.rs`** - Bitbucket Cloud API client
-- **`bitbucket_data_center_api.rs`** - Bitbucket Server API client
-
-## Design Principles
-
-1. **Separation of Concerns**: Business logic (core/) is separate from CLI and external APIs
-2. **Error Handling**: Centralized error types with context-rich messages
-3. **Streaming Output**: Real-time output for long-running operations
-4. **Trait-Based Design**: Provider trait allows easy addition of new git platforms
-5. **Type Safety**: Leveraging Rust's type system for correctness
-
-## Adding New Features
-
-### Adding a New Command
-
-1. Create a new file in `commands/`
-2. Implement the command logic with a `run()` function
-3. Add the command to `cli.rs`
-4. Wire it up in `main.rs`
-
-### Adding a New Provider
-
-1. Create a new file in `providers/`
-2. Implement the `Provider` trait
-3. Update `create_provider()` in `providers/mod.rs`
-
-### Error Handling
-
-Use the centralized error types from `error.rs`:
-
-```rust
-use crate::error::{Error, Result};
-
-// Return errors using the convenience methods
-return Err(Error::git("Git operation failed"));
-return Err(Error::config("Invalid configuration"));
-```
-
-## Testing
-
-- Unit tests are embedded in modules using `#[cfg(test)]`
-- Integration tests are in the `tests/` directory
-- Run tests with `cargo test`
-
-## Code Style
-
-- Format code with `cargo fmt`
-- Line width: 120 characters (configured in rustfmt.toml)
-- Follow Rust naming conventions
-- Add documentation comments for public APIs
+1. Add clap enum variant and args in `cli.rs`
+2. Implement `run(...)` in `src/commands/<name>.rs`
+3. Wire in `match` in `main.rs`


### PR DESCRIPTION
This PR prepares the repository for open‑source publishing.\n\nChanges\n- Condense README.md and CLAUDE.md for clarity and brevity\n- Add MIT LICENSE and set Cargo metadata (license/readme)\n- Fix CI workflow (push/PR triggers, run at repo root, actions/checkout@v4)\n- Tidy internal docs (src/README.md)\n\nValidation\n- cargo test: all tests pass locally\n- cargo build --release: successful\n\nFollow‑ups\n- Optionally add repository URL to Cargo.toml once final\n- Consider a GitHub Releases workflow for binaries when ready